### PR TITLE
FK-56 태스크 생성기능 구현

### DIFF
--- a/src/main/java/com/capston_design/fkiller/itoms/service_request_management/controller/TaskController.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/service_request_management/controller/TaskController.java
@@ -1,13 +1,26 @@
 package com.capston_design.fkiller.itoms.service_request_management.controller;
 
+import com.capston_design.fkiller.itoms.service_request_management.controller.dto.request.CreateTasksRequestDTO;
+import com.capston_design.fkiller.itoms.service_request_management.controller.dto.response.CreateTasksResponseDTO;
+import com.capston_design.fkiller.itoms.service_request_management.controller.dto.response.TaskResponseInformation;
 import com.capston_design.fkiller.itoms.service_request_management.service.TaskService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/service-request-management")
+@RequiredArgsConstructor
 public class TaskController {
 
-    private TaskService taskService;
+    private final TaskService taskService;
+
+    @PostMapping("/v1/task")
+    public CreateTasksResponseDTO createTask(@RequestBody CreateTasksRequestDTO request){
+        TaskResponseInformation taskResponseInformation = taskService.createTask(request);
+        return new CreateTasksResponseDTO(taskResponseInformation);
+    }
 
 }

--- a/src/main/java/com/capston_design/fkiller/itoms/service_request_management/controller/TicketInformationController.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/service_request_management/controller/TicketInformationController.java
@@ -8,7 +8,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
-import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/service-request-management/ticket-info")

--- a/src/main/java/com/capston_design/fkiller/itoms/service_request_management/controller/dto/request/CreateTasksRequestDTO.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/service_request_management/controller/dto/request/CreateTasksRequestDTO.java
@@ -1,0 +1,12 @@
+package com.capston_design.fkiller.itoms.service_request_management.controller.dto.request;
+
+import lombok.Getter;
+
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+public class CreateTasksRequestDTO {
+    private UUID ticketId;
+    private String taskName;
+}

--- a/src/main/java/com/capston_design/fkiller/itoms/service_request_management/controller/dto/response/CreateTasksResponseDTO.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/service_request_management/controller/dto/response/CreateTasksResponseDTO.java
@@ -1,0 +1,12 @@
+package com.capston_design.fkiller.itoms.service_request_management.controller.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class CreateTasksResponseDTO {
+    private TaskResponseInformation taskResponseInformation;
+}

--- a/src/main/java/com/capston_design/fkiller/itoms/service_request_management/controller/dto/response/TaskResponseInformation.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/service_request_management/controller/dto/response/TaskResponseInformation.java
@@ -1,0 +1,17 @@
+package com.capston_design.fkiller.itoms.service_request_management.controller.dto.response;
+
+import com.capston_design.fkiller.itoms.service_request_management.domain.entity.task.TaskStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@AllArgsConstructor
+@Getter
+public class TaskResponseInformation {
+    private UUID ticketId;
+    private UUID incidentId;
+    private UUID taskId;
+    private String taskName;
+    private TaskStatus taskStatus;
+}

--- a/src/main/java/com/capston_design/fkiller/itoms/service_request_management/domain/entity/task/Task.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/service_request_management/domain/entity/task/Task.java
@@ -28,20 +28,8 @@ public class Task extends BaseEntity {
     @JoinColumn(name = "ticket_id", referencedColumnName = "ticket_id", insertable = false, updatable = false)
     private TicketInformation ticketInformation;
 
-    @Column(name = "charger_id", nullable = false)
-    private String chargerId;
-
-    @Column(name = "charger_name", nullable = false)
-    private String chargerName;
-
     @Column(name = "charger_dept")
     private String chargerDept;
-
-    @Column(name = "creator_id", nullable = false)
-    private String creatorId;
-
-    @Column(name = "creator_name", nullable = false)
-    private String creatorName;
 
     @Column(name = "is_deleted", nullable = false)
     private boolean isDeleted;
@@ -69,20 +57,19 @@ public class Task extends BaseEntity {
     private LocalDateTime planDuration;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "status", nullable = false)
-    private TaskStatus status;
+    @Column(name = "task_status", nullable = false)
+    private TaskStatus taskStatus;
 
     @Column(name = "status_code", nullable = false)
     private String statusCode;
 
-    @Column(name = "name", nullable = false)
-    private String name;
+    @Column(name = "task_name", nullable = false)
+    private String taskName;
 
-    @Column(name = "content", columnDefinition = "TEXT")
-    private String content;
+    @Column(name = "task_content", columnDefinition = "TEXT")
+    private String taskContent;
 
-    @Column(name = "active", nullable = false)
-    private boolean active;
-
+    @Column(name = "task_active", nullable = false)
+    private boolean taskActive;
 
 }

--- a/src/main/java/com/capston_design/fkiller/itoms/service_request_management/domain/entity/task/TaskStatus.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/service_request_management/domain/entity/task/TaskStatus.java
@@ -3,7 +3,6 @@ package com.capston_design.fkiller.itoms.service_request_management.domain.entit
 import lombok.Getter;
 
 @Getter
-
 public enum TaskStatus {
     NOT_STARTED("ts1000", "NOT_STARTED", "작업 시작 전"),
     IN_PROGRESS("ts1001", "IN_PROGRESS", "작업 진행 중"),

--- a/src/main/java/com/capston_design/fkiller/itoms/service_request_management/domain/entity/ticket_information/TicketInformation.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/service_request_management/domain/entity/ticket_information/TicketInformation.java
@@ -26,6 +26,7 @@ public class TicketInformation {
     @Column(name = "ticket_content")
     private String ticketContent;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "ticket_status", nullable = false)
     private TicketStatus ticketStatus;
 
@@ -63,4 +64,6 @@ public class TicketInformation {
        this.chargerId = chargerId;
        this.chargerName = chargerName;
    }
+
+
 }

--- a/src/main/java/com/capston_design/fkiller/itoms/service_request_management/domain/task/TaskCreator.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/service_request_management/domain/task/TaskCreator.java
@@ -1,0 +1,19 @@
+package com.capston_design.fkiller.itoms.service_request_management.domain.task;
+
+import com.capston_design.fkiller.itoms.service_request_management.domain.ticket.TicketDomain;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TaskCreator {
+
+    public TaskDomain createInitTaskDomain(String taskName, TicketDomain ticketDomain){
+        return TaskDomain.createInitTaskDomain(
+                ticketDomain.getTicketId(),
+                ticketDomain.getTicketName(),
+                ticketDomain.getIncidentId(),
+                ticketDomain.getChargerId(),
+                ticketDomain.getChargerName(),
+                taskName
+                );
+    }
+}

--- a/src/main/java/com/capston_design/fkiller/itoms/service_request_management/domain/task/TaskDomain.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/service_request_management/domain/task/TaskDomain.java
@@ -1,0 +1,59 @@
+package com.capston_design.fkiller.itoms.service_request_management.domain.task;
+
+import com.capston_design.fkiller.itoms.service_request_management.domain.entity.task.TaskStatus;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class TaskDomain {
+    private UUID taskId;
+    private UUID ticketId;
+    private UUID incidentId;
+    private boolean isDeleted;
+    private TaskStatus taskStatus;
+    private String statusCode;
+    private String taskName;
+    private String taskContent;
+    private boolean taskActive;
+    private  String ticketName;
+    private LocalDateTime ticketPlanStartDate;
+    private LocalDateTime ticketPlanEndDate;
+    private String chargerId;
+    private String chargerName;
+
+    private TaskDomain(UUID ticketId, UUID incidentId, String taskName,
+                      String ticketName, String chargerId, String chargerName) {
+
+        this.ticketId = ticketId;
+        this.incidentId = incidentId;
+        this.isDeleted = false;
+        this.taskStatus = TaskStatus.NOT_STARTED;
+        this.statusCode = TaskStatus.NOT_STARTED.getCode();
+        this.taskName = taskName;
+        this.taskActive = false;
+        this.ticketName = ticketName;
+        this.chargerId = chargerId;
+        this.chargerName = chargerName;
+    }
+
+    public static TaskDomain createInitTaskDomain(UUID ticketId, String ticketName, UUID incidentId,
+                                                String chargerId, String chargerName, String taskName) {
+        return new TaskDomain(ticketId, incidentId,
+                taskName, ticketName, chargerId, chargerName);
+    }
+
+    public static TaskDomain createTaskDomain(UUID taskId, UUID ticketId, UUID incidentId, boolean isDeleted,
+                                              TaskStatus taskStatus, String statusCode, String taskName,
+                                              String taskContent, boolean taskActive, String ticketName,
+                                              LocalDateTime ticketPlanStartDate, LocalDateTime ticketPlanEndDate,
+                                              String chargerId, String chargerName) {
+        return new TaskDomain(taskId, ticketId, incidentId, isDeleted, taskStatus, statusCode,
+                taskName, taskContent, taskActive, ticketName, ticketPlanStartDate,
+                ticketPlanEndDate, chargerId, chargerName);
+    }
+}

--- a/src/main/java/com/capston_design/fkiller/itoms/service_request_management/domain/task/TaskMapper.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/service_request_management/domain/task/TaskMapper.java
@@ -1,0 +1,40 @@
+package com.capston_design.fkiller.itoms.service_request_management.domain.task;
+
+import com.capston_design.fkiller.itoms.service_request_management.controller.dto.response.TaskResponseInformation;
+import com.capston_design.fkiller.itoms.service_request_management.domain.entity.task.Task;
+import com.capston_design.fkiller.itoms.service_request_management.domain.entity.ticket_information.TicketInformation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class TaskMapper {
+
+    private final TaskCreator taskCreator;
+
+    public Task toEntity(TaskDomain taskDomain){
+        return Task.builder()
+                .taskName(taskDomain.getTaskName())
+                .incidentId(taskDomain.getIncidentId())
+                .ticketId(taskDomain.getTicketId())
+                .isDeleted(taskDomain.isDeleted())
+                .taskStatus(taskDomain.getTaskStatus())
+                .statusCode(taskDomain.getStatusCode())
+                .taskContent(taskDomain.getTaskContent())
+                .taskActive(taskDomain.isTaskActive())
+                .build();
+    }
+
+    public TaskResponseInformation toTaskResponseInformation(UUID taskId, TaskDomain taskDomain) {
+        return new TaskResponseInformation(
+                taskDomain.getTicketId(),
+                taskDomain.getIncidentId(),
+                taskId,
+                taskDomain.getTaskName(),
+                taskDomain.getTaskStatus()
+        );
+    }
+}

--- a/src/main/java/com/capston_design/fkiller/itoms/service_request_management/domain/ticket/TicketMapper.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/service_request_management/domain/ticket/TicketMapper.java
@@ -4,11 +4,9 @@ import com.capston_design.fkiller.itoms.service_request_management.client.dto.re
 import com.capston_design.fkiller.itoms.service_request_management.controller.dto.response.TicketInformationResponseDTO;
 import com.capston_design.fkiller.itoms.service_request_management.domain.entity.ticket_information.TicketInformation;
 import lombok.RequiredArgsConstructor;
-import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -32,6 +30,19 @@ public class TicketMapper {
                     ticketInformationDTO.getCreatorName(),
                     ticketInformationDTO.getAcceptorId(),
                     ticketInformationDTO.getAcceptorName());
+    }
+
+    public TicketDomain toTicketDomain(TicketInformation ticketInformation) {
+        return ticketCreator.createInitTicket(
+                ticketInformation.getTicketId(),
+                ticketInformation.getIncidentId(),
+                ticketInformation.getTicketName(),
+                ticketInformation.getTicketContent(),
+                ticketInformation.getTicketStatus(),
+                ticketInformation.getCreatorId(),
+                ticketInformation.getCreatorName(),
+                ticketInformation.getChargerId(),
+                ticketInformation.getChargerName());
     }
 
     public List<TicketInformation> toTicketInformationEntityList(List<TicketDomain> ticketDomainList) {

--- a/src/main/java/com/capston_design/fkiller/itoms/service_request_management/repository/TicketInformationRepository.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/service_request_management/repository/TicketInformationRepository.java
@@ -4,6 +4,10 @@ import com.capston_design.fkiller.itoms.service_request_management.domain.entity
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+import java.util.UUID;
+
 @Repository
 public interface TicketInformationRepository extends JpaRepository<TicketInformation, Long> {
+    Optional<TicketInformation> findByTicketId(UUID ticketId);
 }

--- a/src/main/java/com/capston_design/fkiller/itoms/service_request_management/service/TaskService.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/service_request_management/service/TaskService.java
@@ -1,6 +1,9 @@
 package com.capston_design.fkiller.itoms.service_request_management.service;
 
-import com.capston_design.fkiller.itoms.service_request_management.controller.dto.request.AssignedTicketListRequestDTO;
+import com.capston_design.fkiller.itoms.service_request_management.controller.dto.request.CreateTasksRequestDTO;
+import com.capston_design.fkiller.itoms.service_request_management.controller.dto.response.TaskResponseInformation;
+
 
 public interface TaskService {
+    TaskResponseInformation createTask(CreateTasksRequestDTO request);
 }

--- a/src/main/java/com/capston_design/fkiller/itoms/service_request_management/service/TaskServiceImpl.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/service_request_management/service/TaskServiceImpl.java
@@ -1,10 +1,35 @@
 package com.capston_design.fkiller.itoms.service_request_management.service;
 
+import com.capston_design.fkiller.itoms.service_request_management.controller.dto.request.CreateTasksRequestDTO;
+import com.capston_design.fkiller.itoms.service_request_management.controller.dto.response.TaskResponseInformation;
+import com.capston_design.fkiller.itoms.service_request_management.domain.entity.ticket_information.TicketInformation;
+import com.capston_design.fkiller.itoms.service_request_management.domain.task.TaskCreator;
+import com.capston_design.fkiller.itoms.service_request_management.domain.task.TaskDomain;
+import com.capston_design.fkiller.itoms.service_request_management.domain.task.TaskMapper;
+import com.capston_design.fkiller.itoms.service_request_management.domain.ticket.TicketDomain;
+import com.capston_design.fkiller.itoms.service_request_management.repository.TaskRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class TaskServiceImpl implements TaskService{
 
+    private final TicketInformationService ticketInformationService;
+    private final TaskRepository taskRepository;
+    private final TaskMapper taskMapper;
+    private final TaskCreator taskCreator;
+
+    @Transactional
+    @Override
+    public TaskResponseInformation createTask(CreateTasksRequestDTO request) {
+        TicketDomain ticketDomain = ticketInformationService.getTicketInformation(request.getTicketId());
+        TaskDomain taskDomain = taskCreator.createInitTaskDomain(request.getTaskName(), ticketDomain);
+        UUID taskId = taskRepository.save(taskMapper.toEntity(taskDomain)).getId();
+        return taskMapper.toTaskResponseInformation(taskId, taskDomain);
+    }
 }

--- a/src/main/java/com/capston_design/fkiller/itoms/service_request_management/service/TicketInformationService.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/service_request_management/service/TicketInformationService.java
@@ -1,11 +1,12 @@
 package com.capston_design.fkiller.itoms.service_request_management.service;
 
-import com.capston_design.fkiller.itoms.service_request_management.controller.dto.request.AssignedTicketListRequestDTO;
 import com.capston_design.fkiller.itoms.service_request_management.controller.dto.response.TicketInformationResponseDTO;
+import com.capston_design.fkiller.itoms.service_request_management.domain.ticket.TicketDomain;
 
 import java.util.List;
 import java.util.UUID;
 
 public interface TicketInformationService {
     List<TicketInformationResponseDTO> getTicketList(String acceptorId);
+    TicketDomain getTicketInformation(UUID ticketId);
 }

--- a/src/main/java/com/capston_design/fkiller/itoms/service_request_management/service/TicketInformationServiceImpl.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/service_request_management/service/TicketInformationServiceImpl.java
@@ -2,8 +2,10 @@ package com.capston_design.fkiller.itoms.service_request_management.service;
 
 import com.capston_design.fkiller.itoms.service_request_management.client.TicketCoreClient;
 import com.capston_design.fkiller.itoms.service_request_management.client.dto.request.TicketListRequestDTO;
-import com.capston_design.fkiller.itoms.service_request_management.controller.dto.request.AssignedTicketListRequestDTO;
+import com.capston_design.fkiller.itoms.service_request_management.common.exception.BaseException;
 import com.capston_design.fkiller.itoms.service_request_management.controller.dto.response.TicketInformationResponseDTO;
+import com.capston_design.fkiller.itoms.service_request_management.domain.entity.ticket_information.TicketInformation;
+import com.capston_design.fkiller.itoms.service_request_management.domain.ticket.TicketDomain;
 import com.capston_design.fkiller.itoms.service_request_management.domain.ticket.TicketMapper;
 import com.capston_design.fkiller.itoms.service_request_management.repository.TicketInformationRepository;
 import lombok.RequiredArgsConstructor;
@@ -31,6 +33,13 @@ public class TicketInformationServiceImpl implements TicketInformationService {
                     return ticketMapper.toTicketInformationResponseDTOList(ticketDomainList);
                 })
                 .orElse(Collections.emptyList());
+    }
+
+    @Override
+    public TicketDomain getTicketInformation(UUID ticketId) {
+        TicketInformation ticketInformation = ticketInformationRepository.findByTicketId(ticketId)
+                .orElseThrow(() -> BaseException.createBaseExceptionWithoutDetail(400, "유효하지 않은 티켓ID 입니다."));
+        return ticketMapper.toTicketDomain(ticketInformation);
     }
 
 }


### PR DESCRIPTION
- ticketId와 taskName을 넘기면 태스크 DB에 저장 후 관련 정보 반환
- jira의 경우 하나씩 입력 받는 구조라 단일로 받는 형태로 구성함
- TicketInfo와 겹치는 Task 엔티티 필드 제거

➕ 추가 논의 필요 사항
- request, response는 어떻게 하는게 좋을까 🧐