### PR TITLE
FK-59 티켓 완료 처리 기능

### DIFF
--- a/src/main/java/com/capston_design/fkiller/itoms/service_request_management/client/TicketCoreClient.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/service_request_management/client/TicketCoreClient.java
@@ -2,6 +2,7 @@ package com.capston_design.fkiller.itoms.service_request_management.client;
 
 import com.capston_design.fkiller.itoms.service_request_management.client.dto.request.TicketListRequestDTO;
 import com.capston_design.fkiller.itoms.service_request_management.client.dto.request.UpdateTaskStatusRequestDTO;
+import com.capston_design.fkiller.itoms.service_request_management.client.dto.request.UpdateTicketStatusRequestDTO;
 import com.capston_design.fkiller.itoms.service_request_management.client.dto.response.TicketInformationDTO;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -20,5 +21,6 @@ public interface TicketCoreClient {
     void updateTaskStatus(@PathVariable UUID taskId,
                           @RequestBody UpdateTaskStatusRequestDTO request);
 
-
+    @PostMapping("/callback/v1/ticket/complete")
+    void updateTicketStatus(@RequestBody  UpdateTicketStatusRequestDTO updateTicketStatusRequestDTO);
 }

--- a/src/main/java/com/capston_design/fkiller/itoms/service_request_management/client/dto/request/UpdateTicketStatusRequestDTO.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/service_request_management/client/dto/request/UpdateTicketStatusRequestDTO.java
@@ -1,0 +1,15 @@
+package com.capston_design.fkiller.itoms.service_request_management.client.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@AllArgsConstructor
+@Getter
+public class UpdateTicketStatusRequestDTO {
+    private UUID ticketId;
+    private String ticketName;
+    private String ticketStatus;
+    private String completionTime;
+}

--- a/src/main/java/com/capston_design/fkiller/itoms/service_request_management/controller/TaskController.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/service_request_management/controller/TaskController.java
@@ -31,6 +31,4 @@ public class TaskController {
         return taskService.updateTaskStatus(task_id, taskStatus, clockHolder.now());
     }
 
-
-
 }

--- a/src/main/java/com/capston_design/fkiller/itoms/service_request_management/controller/TicketInformationController.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/service_request_management/controller/TicketInformationController.java
@@ -1,10 +1,13 @@
 package com.capston_design.fkiller.itoms.service_request_management.controller;
 
+import com.capston_design.fkiller.itoms.service_request_management.common.service.ClockHolder;
 import com.capston_design.fkiller.itoms.service_request_management.controller.dto.request.AssignedTicketListRequestDTO;
+import com.capston_design.fkiller.itoms.service_request_management.controller.dto.request.completeTicketRequestDTO;
 import com.capston_design.fkiller.itoms.service_request_management.controller.dto.response.AssignedTicketListResponseDTO;
 import com.capston_design.fkiller.itoms.service_request_management.controller.dto.response.TicketInformationResponseDTO;
 import com.capston_design.fkiller.itoms.service_request_management.service.TicketInformationService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -15,12 +18,19 @@ import java.util.List;
 public class TicketInformationController {
 
     private final TicketInformationService ticketInformationService;
+    private final ClockHolder clockHolder;
 
     @PostMapping("/v1/tickets")
     public AssignedTicketListResponseDTO getTicketList(@RequestBody AssignedTicketListRequestDTO request) {
         List<TicketInformationResponseDTO> ticketInformationServiceTicketList =
                 ticketInformationService.getTicketList(request.getChargerId());
         return new AssignedTicketListResponseDTO(ticketInformationServiceTicketList);
+    }
+
+    @PostMapping("/v1/ticket/complete")
+    public ResponseEntity<Void> completeTicket(@RequestBody completeTicketRequestDTO request) {
+        ticketInformationService.completeTicket(request, clockHolder.now());
+        return ResponseEntity.ok().build();
     }
 
 }

--- a/src/main/java/com/capston_design/fkiller/itoms/service_request_management/controller/dto/request/completeTicketRequestDTO.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/service_request_management/controller/dto/request/completeTicketRequestDTO.java
@@ -1,0 +1,10 @@
+package com.capston_design.fkiller.itoms.service_request_management.controller.dto.request;
+
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+public class completeTicketRequestDTO {
+    private UUID ticketId;
+}

--- a/src/main/java/com/capston_design/fkiller/itoms/service_request_management/domain/entity/ticket_information/TicketInformation.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/service_request_management/domain/entity/ticket_information/TicketInformation.java
@@ -65,4 +65,8 @@ public class TicketInformation {
        this.chargerName = chargerName;
    }
 
+   public void updateTicketStatus(TicketStatus ticketStatus) {
+       this.ticketStatus = ticketStatus;
+   }
+
 }

--- a/src/main/java/com/capston_design/fkiller/itoms/service_request_management/repository/TaskRepository.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/service_request_management/repository/TaskRepository.java
@@ -4,9 +4,11 @@ import com.capston_design.fkiller.itoms.service_request_management.domain.entity
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.UUID;
 
 @Repository
 public interface TaskRepository extends JpaRepository<Task, UUID> {
 
+    List<Task> findAllByTicketId(UUID ticketId);
 }

--- a/src/main/java/com/capston_design/fkiller/itoms/service_request_management/service/TaskServiceImpl.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/service_request_management/service/TaskServiceImpl.java
@@ -12,7 +12,7 @@ import com.capston_design.fkiller.itoms.service_request_management.domain.task.T
 import com.capston_design.fkiller.itoms.service_request_management.domain.ticket.TicketDomain;
 import com.capston_design.fkiller.itoms.service_request_management.repository.TaskRepository;
 import com.capston_design.fkiller.itoms.service_request_management.service.dto.TaskStatusUpdateEvent;
-import com.capston_design.fkiller.itoms.service_request_management.service.event.rest.RestTaskStausUpdateEventListener;
+import com.capston_design.fkiller.itoms.service_request_management.service.event.rest.RestTaskEventListener;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -26,7 +26,7 @@ import java.util.UUID;
 public class TaskServiceImpl implements TaskService{
 
     private final TicketInformationService ticketInformationService;
-    private final RestTaskStausUpdateEventListener restTaskStausUpdateEventListener;
+    private final RestTaskEventListener restTaskEventListener;
     private final TaskRepository taskRepository;
     private final TaskMapper taskMapper;
     private final TaskCreator taskCreator;
@@ -47,7 +47,7 @@ public class TaskServiceImpl implements TaskService{
                 .orElseThrow(() -> BaseException.createBaseExceptionWithoutDetail(HttpStatus.BAD_REQUEST,
                         "유효하지 않은 Task ID 입니다."));
         task.updateTaskStatus(TaskStatus.fromCodeName(taskStatus));
-        restTaskStausUpdateEventListener.handleTaskStatusUpdateEvent(
+        restTaskEventListener.handleTaskStatusUpdateEvent(
                 new TaskStatusUpdateEvent(task_id, task.getTicketId(), task.getTaskName(), taskStatus, updatedTime));
         Task updateTask = taskRepository.save(task);
 

--- a/src/main/java/com/capston_design/fkiller/itoms/service_request_management/service/TicketInformationService.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/service_request_management/service/TicketInformationService.java
@@ -1,5 +1,6 @@
 package com.capston_design.fkiller.itoms.service_request_management.service;
 
+import com.capston_design.fkiller.itoms.service_request_management.controller.dto.request.completeTicketRequestDTO;
 import com.capston_design.fkiller.itoms.service_request_management.controller.dto.response.TicketInformationResponseDTO;
 import com.capston_design.fkiller.itoms.service_request_management.domain.ticket.TicketDomain;
 
@@ -9,4 +10,5 @@ import java.util.UUID;
 public interface TicketInformationService {
     List<TicketInformationResponseDTO> getTicketList(String acceptorId);
     TicketDomain getTicketInformation(UUID ticketId);
+    void completeTicket(completeTicketRequestDTO request, String completionTime);
 }

--- a/src/main/java/com/capston_design/fkiller/itoms/service_request_management/service/TicketInformationServiceImpl.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/service_request_management/service/TicketInformationServiceImpl.java
@@ -3,11 +3,16 @@ package com.capston_design.fkiller.itoms.service_request_management.service;
 import com.capston_design.fkiller.itoms.service_request_management.client.TicketCoreClient;
 import com.capston_design.fkiller.itoms.service_request_management.client.dto.request.TicketListRequestDTO;
 import com.capston_design.fkiller.itoms.service_request_management.common.exception.BaseException;
+import com.capston_design.fkiller.itoms.service_request_management.controller.dto.request.completeTicketRequestDTO;
 import com.capston_design.fkiller.itoms.service_request_management.controller.dto.response.TicketInformationResponseDTO;
 import com.capston_design.fkiller.itoms.service_request_management.domain.entity.ticket_information.TicketInformation;
+import com.capston_design.fkiller.itoms.service_request_management.domain.entity.ticket_information.TicketStatus;
 import com.capston_design.fkiller.itoms.service_request_management.domain.ticket.TicketDomain;
 import com.capston_design.fkiller.itoms.service_request_management.domain.ticket.TicketMapper;
 import com.capston_design.fkiller.itoms.service_request_management.repository.TicketInformationRepository;
+import com.capston_design.fkiller.itoms.service_request_management.service.dto.TicketStatusUpdateEvent;
+import com.capston_design.fkiller.itoms.service_request_management.service.event.rest.RestTicketEventListener;
+import com.capston_design.fkiller.itoms.service_request_management.validator.TaskValidator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -22,7 +27,9 @@ public class TicketInformationServiceImpl implements TicketInformationService {
 
     private final TicketCoreClient ticketCoreClient;
     private final TicketInformationRepository ticketInformationRepository;
+    private final RestTicketEventListener restTicketEventListener;
     private final TicketMapper ticketMapper;
+    private final TaskValidator taskValidator;
 
     @Override
     @Transactional
@@ -39,8 +46,28 @@ public class TicketInformationServiceImpl implements TicketInformationService {
     @Override
     public TicketDomain getTicketInformation(UUID ticketId) {
         TicketInformation ticketInformation = ticketInformationRepository.findByTicketId(ticketId)
-                .orElseThrow(() -> BaseException.createBaseExceptionWithoutDetail(HttpStatus.BAD_REQUEST, "유효하지 않은 티켓ID 입니다."));
+                .orElseThrow(() -> BaseException
+                        .createBaseExceptionWithoutDetail(HttpStatus.BAD_REQUEST, "유효하지 않은 티켓ID 입니다."));
         return ticketMapper.toTicketDomain(ticketInformation);
+    }
+
+    @Override
+    public void completeTicket(completeTicketRequestDTO request, String completionTime) {
+        TicketInformation ticketInformation = ticketInformationRepository.findByTicketId(request.getTicketId())
+                .orElseThrow(() -> BaseException
+                        .createBaseExceptionWithoutDetail(HttpStatus.BAD_REQUEST, "유효하지 않은 티켓ID 입니다."));
+
+        if(taskValidator.checkAllTaskCompleted(request.getTicketId())){
+            ticketInformation.updateTicketStatus(TicketStatus.COMPLETE_EXECUTION);
+            restTicketEventListener.handleTicketStatusUpdateEvent(
+                    new TicketStatusUpdateEvent(request.getTicketId(), ticketInformation.getTicketName(),
+                            TicketStatus.COMPLETE_EXECUTION.getCodeName(), completionTime)
+            );
+            ticketInformationRepository.save(ticketInformation);
+        } else {
+            throw BaseException.createBaseExceptionWithoutDetail(
+                    HttpStatus.BAD_REQUEST, "해당 티켓에 할당된 작업이 모두 완료되지 않았습니다.");
+        }
     }
 
 }

--- a/src/main/java/com/capston_design/fkiller/itoms/service_request_management/service/dto/TicketStatusUpdateEvent.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/service_request_management/service/dto/TicketStatusUpdateEvent.java
@@ -1,0 +1,15 @@
+package com.capston_design.fkiller.itoms.service_request_management.service.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+@AllArgsConstructor
+public class TicketStatusUpdateEvent {
+    private UUID ticketId;
+    private String ticketName;
+    private String ticketStatus;
+    private String completionTime;
+}

--- a/src/main/java/com/capston_design/fkiller/itoms/service_request_management/service/event/rest/RestTaskEventListener.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/service_request_management/service/event/rest/RestTaskEventListener.java
@@ -1,0 +1,27 @@
+package com.capston_design.fkiller.itoms.service_request_management.service.event.rest;
+
+import com.capston_design.fkiller.itoms.service_request_management.client.TicketCoreClient;
+import com.capston_design.fkiller.itoms.service_request_management.client.dto.request.UpdateTaskStatusRequestDTO;
+import com.capston_design.fkiller.itoms.service_request_management.service.dto.TaskStatusUpdateEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RestTaskEventListener {
+    private final TicketCoreClient ticketCoreClient;
+
+    @Async
+    @EventListener
+    public void handleTaskStatusUpdateEvent(TaskStatusUpdateEvent event) {
+        ticketCoreClient.updateTaskStatus(event.getTaskId(),
+                new UpdateTaskStatusRequestDTO(
+                        event.getTicketId(),
+                        event.getTaskName(),
+                        event.getTaskStatus(),
+                        event.getCompletionTime()
+                ));
+    }
+}

--- a/src/main/java/com/capston_design/fkiller/itoms/service_request_management/service/event/rest/RestTicketEventListener.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/service_request_management/service/event/rest/RestTicketEventListener.java
@@ -1,8 +1,8 @@
 package com.capston_design.fkiller.itoms.service_request_management.service.event.rest;
 
 import com.capston_design.fkiller.itoms.service_request_management.client.TicketCoreClient;
-import com.capston_design.fkiller.itoms.service_request_management.client.dto.request.UpdateTaskStatusRequestDTO;
-import com.capston_design.fkiller.itoms.service_request_management.service.dto.TaskStatusUpdateEvent;
+import com.capston_design.fkiller.itoms.service_request_management.client.dto.request.UpdateTicketStatusRequestDTO;
+import com.capston_design.fkiller.itoms.service_request_management.service.dto.TicketStatusUpdateEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
@@ -10,17 +10,17 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class RestTaskStausUpdateEventListener {
+public class RestTicketEventListener {
     private final TicketCoreClient ticketCoreClient;
 
     @Async
     @EventListener
-    public void handleTaskStatusUpdateEvent(TaskStatusUpdateEvent event) {
-        ticketCoreClient.updateTaskStatus(event.getTaskId(),
-                new UpdateTaskStatusRequestDTO(
+    public void handleTicketStatusUpdateEvent(TicketStatusUpdateEvent event) {
+        ticketCoreClient.updateTicketStatus(
+                new UpdateTicketStatusRequestDTO(
                         event.getTicketId(),
-                        event.getTaskName(),
-                        event.getTaskStatus(),
+                        event.getTicketName(),
+                        event.getTicketStatus(),
                         event.getCompletionTime()
                 ));
     }

--- a/src/main/java/com/capston_design/fkiller/itoms/service_request_management/validator/TaskValidator.java
+++ b/src/main/java/com/capston_design/fkiller/itoms/service_request_management/validator/TaskValidator.java
@@ -1,13 +1,32 @@
 package com.capston_design.fkiller.itoms.service_request_management.validator;
 
+import com.capston_design.fkiller.itoms.service_request_management.common.exception.BaseException;
+import com.capston_design.fkiller.itoms.service_request_management.domain.entity.task.Task;
+import com.capston_design.fkiller.itoms.service_request_management.domain.entity.task.TaskStatus;
+import com.capston_design.fkiller.itoms.service_request_management.repository.TaskRepository;
 import com.capston_design.fkiller.itoms.service_request_management.repository.TicketInformationRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.UUID;
 
 @Component
 @RequiredArgsConstructor
 public class TaskValidator {
     private final TicketInformationRepository ticketInformationRepository;
+    private final TaskRepository taskRepository;
+
+    public boolean checkAllTaskCompleted(UUID ticketId){
+        List<Task> taskList = taskRepository.findAllByTicketId(ticketId);
+        if (taskList.isEmpty()) {
+            throw BaseException.createBaseExceptionWithoutDetail(
+                    HttpStatus.BAD_REQUEST, "해당 티켓에 할당된 작업이 없습니다.");
+        }
+        return taskList.stream()
+                .allMatch(task -> task.getTaskStatus() == TaskStatus.COMPLETED);
+    }
 
 
 }


### PR DESCRIPTION
- Ticket ID를 기준으로 해당 티켓이 완료되었다는 요청
- 티켓에 대한 태스크 검증 수행 1️⃣ 태스크가 없는 상태로 했다면 예외처리
2️⃣ 생성된 모든 태스크의 status가 완료 상태가 아니면 예외처리
- TicketInformation에 완료 Status로 변경

- TicketCore에 티켓이 완료되었음을 전송
- 전송 데이터 1️⃣ 티켓 ID
2️⃣ 티켓 이름
3️⃣ 티켓 상태
4️⃣ 완료 Time